### PR TITLE
added checks for hpc data-staging logging requirements

### DIFF
--- a/mlperf_logging/compliance_checker/hpc_0.5.0/common.yaml
+++ b/mlperf_logging/compliance_checker/hpc_0.5.0/common.yaml
@@ -20,6 +20,7 @@
             'init_stopped' : False,
             'run_started' : False,
             'run_stopped' : False,
+            'stage_started': False,
             'in_epoch' : False,
             'last_epoch' : 0,
             'in_block' : False,
@@ -94,6 +95,18 @@
         - "s['run_started']"
         - "'status' in v['metadata']"
     POST:  " s['run_stopped'] = True "
+
+# HPC requires data staging to be included in run timing
+- KEY:
+    NAME: stage_start
+    CHECK:
+        - "s['run_started']"
+    POST: " s['stage_started'] = True "
+
+- KEY:
+    NAME: stage_stop
+    CHECK:
+        - "s['stage_started']"
 
 # FIXME: check epoch_count value match
 - KEY:

--- a/mlperf_logging/compliance_checker/hpc_0.5.0/common.yaml
+++ b/mlperf_logging/compliance_checker/hpc_0.5.0/common.yaml
@@ -20,7 +20,7 @@
             'init_stopped' : False,
             'run_started' : False,
             'run_stopped' : False,
-            'stage_started': False,
+            'staging_started': False,
             'in_epoch' : False,
             'last_epoch' : 0,
             'in_block' : False,
@@ -98,15 +98,15 @@
 
 # HPC requires data staging to be included in run timing
 - KEY:
-    NAME: stage_start
+    NAME: staging_start
     CHECK:
         - "s['run_started']"
-    POST: " s['stage_started'] = True "
+    POST: " s['staging_started'] = True "
 
 - KEY:
-    NAME: stage_stop
+    NAME: staging_stop
     CHECK:
-        - "s['stage_started']"
+        - "s['staging_started']"
 
 # FIXME: check epoch_count value match
 - KEY:

--- a/mlperf_logging/mllog/constants.py
+++ b/mlperf_logging/mllog/constants.py
@@ -67,6 +67,8 @@ INIT_START = "init_start"
 INIT_STOP = "init_stop"
 RUN_START = "run_start"
 RUN_STOP = "run_stop"
+STAGING_START = "staging_start"
+STAGING_STOP = "staging_stop"
 
 # Log keys - common run info
 CACHE_CLEAR = "cache_clear"


### PR DESCRIPTION
Adding some requirements that the start and stop of data-staging logging must occur after run_start. Not yet requiring that data staging be logged.